### PR TITLE
HOCS-1746 Use ACP Quay.io proxy

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: registrykey
       initContainers:
         - name: truststore
-          image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.6
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.6
           securityContext:
             runAsNonRoot: true
             capabilities:
@@ -54,7 +54,7 @@ spec:
             readOnly: true
       containers:
         - name: certs
-          image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.6
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick:v0.0.6
           securityContext:
             runAsNonRoot: true
             capabilities:
@@ -79,7 +79,7 @@ spec:
               readOnly: true
 
         - name: proxy
-          image: quay.io/ukhomeofficedigital/nginx-proxy:v3.2.9
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/nginx-proxy:v3.2.9
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
@@ -129,7 +129,7 @@ spec:
             - name: https
               containerPort: 10443
         - name: hocs-info-service
-          image: quay.io/ukhomeofficedigital/hocs-info-service:{{.VERSION}}
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/hocs-info-service:{{.VERSION}}
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This commit changes references to Quay.io to a Home Office hosted proxy
of Quay.io. This will mean that if Quay.io is unavailable, previously
pulled images will still be available for download. However, it would
still not be possible to push new images, which must go to Quay
directly.

This merely moves the single point of failure, but to one that is within
the Home Office's responsibility and therefore might be easier to fix.

If the ACP mirror goes down, you can revert this commit without
consequence.