### PR TITLE
Hocs 1925 dcu data limits

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -307,7 +307,7 @@ spec:
           resources:
             limits:
               cpu: 1200m
-              memory: 2024Mi
+              memory: 2048Mi
             requests:
               cpu: 200m
               memory: 896Mi

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -306,8 +306,8 @@ spec:
                   fieldPath: metadata.namespace
           resources:
             limits:
-              cpu: 900m
-              memory: 1536Mi
+              cpu: 1200m
+              memory: 2024Mi
             requests:
               cpu: 200m
               memory: 896Mi


### PR DESCRIPTION
HOCS-1925
The new DCU data has caused the system to hit memory and cpu usage limits (lots of recycling on the services and also errors on the automated tests).
This service is one of many to be changed so that the system is able to handle the new data size.