### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,46 +17,39 @@ else
     export HOCS_DATA_REPO=hocs-data-wcs
 fi
 
+if [[ ${KUBE_NAMESPACE} == *prod ]]
+then
+    export MIN_REPLICAS="2"
+    export MAX_REPLICAS="6"
+else
+    export MIN_REPLICAS="1"
+    export MAX_REPLICAS="2"
+fi
+
 if [[ ${KUBE_NAMESPACE} == "cs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_INFO_SERVICE_PROD_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_PROD_CS}
-    export REPLICAS="2"
-    export MAX_REPLICAS="6"
 elif [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_INFO_SERVICE_PROD_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_PROD_WCS}
-    export REPLICAS="2"
-    export MAX_REPLICAS="6"
 elif [[ ${KUBE_NAMESPACE} == "cs-qa" ]] ; then
     echo "deploy ${VERSION} to test namespace, using HOCS_INFO_SERVICE_QA_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_QA_CS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "wcs-qa" ]] ; then
     echo "deploy ${VERSION} to test namespace, using HOCS_INFO_SERVICE_QA_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_QA_WCS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "cs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_INFO_SERVICE_DEMO_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEMO_CS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 elif  [[ ${KUBE_NAMESPACE} == "wcs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_INFO_SERVICE_DEMO_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEMO_WCS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "cs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_INFO_SERVICE_DEV_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEV_CS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_INFO_SERVICE_DEV_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEV_WCS}
-    export REPLICAS="1"
-    export MAX_REPLICAS="3"
 else
     echo "Unable to find environment: ${ENVIRONMENT}"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,34 +21,42 @@ if [[ ${KUBE_NAMESPACE} == "cs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_INFO_SERVICE_PROD_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_PROD_CS}
     export REPLICAS="2"
+    export MAX_REPLICAS="6"
 elif [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_INFO_SERVICE_PROD_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_PROD_WCS}
     export REPLICAS="2"
+    export MAX_REPLICAS="6"
 elif [[ ${KUBE_NAMESPACE} == "cs-qa" ]] ; then
     echo "deploy ${VERSION} to test namespace, using HOCS_INFO_SERVICE_QA_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_QA_CS}
-    export REPLICAS="2"
+    export REPLICAS="1"
+    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "wcs-qa" ]] ; then
     echo "deploy ${VERSION} to test namespace, using HOCS_INFO_SERVICE_QA_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_QA_WCS}
-    export REPLICAS="2"
+    export REPLICAS="1"
+    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "cs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_INFO_SERVICE_DEMO_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEMO_CS}
     export REPLICAS="1"
+    export MAX_REPLICAS="3"
 elif  [[ ${KUBE_NAMESPACE} == "wcs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_INFO_SERVICE_DEMO_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEMO_WCS}
     export REPLICAS="1"
+    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "cs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_INFO_SERVICE_DEV_CS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEV_CS}
     export REPLICAS="1"
+    export MAX_REPLICAS="3"
 elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_INFO_SERVICE_DEV_WCS drone secret"
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEV_WCS}
     export REPLICAS="1"
+    export MAX_REPLICAS="3"
 else
     echo "Unable to find environment: ${ENVIRONMENT}"
 fi

--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hocs-info-service
 spec:
   maxReplicas: {{.MAX_REPLICAS}}
-  minReplicas: {{.REPLICAS}}
+  minReplicas: {{.MIN_REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -5,7 +5,7 @@ metadata:
     app: hocs-info-service
   name: hocs-info-service
 spec:
-  maxReplicas: 2
+  maxReplicas: {{.MAX_REPLICAS}}
   minReplicas: {{.REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     version: {{.VERSION}}
 spec:
-  replicas: {{.REPLICAS}}
+  replicas: {{.MIN_REPLICAS}}
   selector:
     matchLabels:
       name: hocs-info-service


### PR DESCRIPTION
The max_replicas is now set per namespace in the deploy script, and utilised in the autoscaler.
All not-prod environments can handle a maximum of 3 instances per service (which is limited by the maximum database connections)
The prod environments have more than double the capacity.