### PR TITLE
Use valid exit codes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -52,11 +52,12 @@ elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
     export KUBE_TOKEN=${HOCS_INFO_SERVICE_DEV_WCS}
 else
     echo "Unable to find environment: ${ENVIRONMENT}"
+    exit 1
 fi
 
 if [[ -z ${KUBE_TOKEN} ]] ; then
     echo "Failed to find a value for KUBE_TOKEN - exiting"
-    exit -1
+    exit 1
 fi
 
 cd kd


### PR DESCRIPTION
You can only exit using an integer between 0 and 255 inclusive.
Negative one isn't between those values and is invalid.

(Invalid arguments to `exit` result in an exit code of 128.)