### PR TITLE
HOCS-2095: Add topic name to environment variables

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -308,6 +308,8 @@ spec:
                 secretKeyRef:
                   name: '{{.KUBE_NAMESPACE}}-keycloak'
                   key: keycloak_client_id
+            - name: AUDIT_TOPIC_NAME
+              value: {{.KUBE_NAMESPACE}}-sns
             - name: AUDIT_AWS_SNS_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
As a result of a production live issue that means that nothing from the hocs-info-service was sending to logging successfully, we have attained that the topic name is not being correctly set within the deployment. This is now added and follows the same path as the other projects we have.