### PR TITLE
HOCS-2188 QA Stability Issues

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -111,11 +111,11 @@ spec:
                   key: rds_password
           resources:
             limits:
-              memory: 32Mi
-              cpu: 400m
+              memory: 64Mi
+              cpu: 600m
             requests:
-              memory: 4Mi
-              cpu: 100m
+              memory: 16Mi
+              cpu: 200m
 
         - name: hocs-info-service-data-migration
           image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/{{.HOCS_DATA_REPO}}:{{.HOCS_INFO_SERVICE_DATA_VERSION}}
@@ -138,6 +138,13 @@ spec:
                 secretKeyRef:
                   name: hocs-info-service
                   key: rds_password
+          resources:
+            limits:
+              cpu: 600m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 16Mi
 
       containers:
         - name: certs
@@ -235,7 +242,7 @@ spec:
                 name: hocs-queue-config
           env:
             - name: JAVA_OPTS
-              value: '-Xms384m -Xmx1536m -XX:+UseG1GC -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: '-Xms384m -Xmx2048m -XX:+UseG1GC -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
             - name: JDK_TRUST_FILE
               value: '/etc/keystore/truststore.jks'
             - name: SERVER_PORT

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -111,8 +111,8 @@ spec:
                   key: rds_password
           resources:
             limits:
-              memory: 64Mi
               cpu: 600m
+              memory: 64Mi
             requests:
               memory: 16Mi
               cpu: 200m

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -114,8 +114,8 @@ spec:
               cpu: 600m
               memory: 64Mi
             requests:
-              memory: 16Mi
               cpu: 200m
+              memory: 16Mi
 
         - name: hocs-info-service-data-migration
           image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/{{.HOCS_DATA_REPO}}:{{.HOCS_INFO_SERVICE_DATA_VERSION}}


### PR DESCRIPTION
Flyway db memory/cpu modified from default 400mi/400m.
Database provisioning increased.
JDK limit set to image memory limit of 2G.

The following was used to verify these changes:
1. full test pack was run against CS QA.
2. kibana logs were inspected; there were no exception logs.
3. sysdig showed expected patterns of ideal pod operation, for all pods.