### PR TITLE
HOCS-2215 Remove errant quotation marks

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -246,9 +246,9 @@ spec:
                 -Xms384m -Xmx2048m -XX:+UseG1GC
                 -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks
                 -Dhttp.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttp.proxyPort=31290
-                -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+                -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290
-                -Dhttps.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+                -Dhttps.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
             - name: JDK_TRUST_FILE
               value: '/etc/keystore/truststore.jks'
             - name: SERVER_PORT


### PR DESCRIPTION
Quotation marks were accidentally left in the previous commit, causing
the configuration to not work correctly. This commit removes them.