### PR TITLE
Fix refresh members cron job

### DIFF
--- a/kd/refreshmembers.yaml
+++ b/kd/refreshmembers.yaml
@@ -9,10 +9,12 @@ spec:
       backoffLimit: 3
       template:
         metadata:
-          labels: hocs-backend
+          labels:
+            name: hocs-refresh-members-job
+            role: hocs-backend
         spec:
           containers:
-            - name: hocs-refersh-members-job
+            - name: hocs-refresh-members-job
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000


### PR DESCRIPTION
Currently the cron job change is failing on due to the 
metadata.label expecting a map and not a string. This change 
corrects the name of the container and also adds the correct 
metadata labels.