### PR TITLE
HOCS-2743: add notify env variables

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -341,6 +341,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NOTIFY_QUEUE_NAME	
+              value:	
+                {{.KUBE_NAMESPACE}}-notify-sqs
+            - name: NOTIFY_QUEUE_DLQ_NAME	
+              value:	
+                {{.KUBE_NAMESPACE}}-notify-sqs-dlq
+            - name: NOTIFY_AWS_SQS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-notify-sqs
+                  key: access_key_id
+            - name: NOTIFY_AWS_SQS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-notify-sqs
+                  key: secret_access_key
           resources:
             limits:
               cpu: 1200m


### PR DESCRIPTION
As we are now going to be sending notify events for changing team 
names we need to pass through the notify environment variables 
and secrets. This change adds this to the deployment.